### PR TITLE
[TM only] doubles the speed of every projectile

### DIFF
--- a/code/controllers/subsystem/processing/projectiles.dm
+++ b/code/controllers/subsystem/processing/projectiles.dm
@@ -17,4 +17,4 @@ PROCESSING_SUBSYSTEM_DEF(projectiles)
 	 * assume that 1 speed = 1 tile per decisecond, but this is a variable so that admins/debuggers can edit
 	 * in order to debug projectile behavior by evenly slowing or speeding all of them up.
 	 */
-	var/pixels_per_decisecond = ICON_SIZE_ALL
+	var/pixels_per_decisecond = ICON_SIZE_ALL * 2


### PR DESCRIPTION
what could go wrong?

## About The Pull Request

this affects every proj in the game as you can see. it may be that it's better to keep some projectiles slower which can be hashed out. but i just made this for testing

## Why It's Good For The Game

have discussed this with multiple maintainers multiple times and there was a lot of interest in a tm pr like this i believe

## Changelog

:cl:
balance: all projectiles are now twice as fast
/:cl: